### PR TITLE
Remove instanceof Ember.View check.

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
 
   _tetherTarget: computed('target', function() {
     let t = get(this, 'target');
-    if (t instanceof Ember.View) {
+    if (t && t.element) {
       t = t.element;
     }
     return t;

--- a/tests/acceptance/tether-test.js
+++ b/tests/acceptance/tether-test.js
@@ -3,7 +3,7 @@ import QUnit from 'qunit';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
 
-var application;
+var application, viewRegistry;
 const assert = QUnit.assert;
 const abs = Math.abs;
 const set = Ember.set;
@@ -11,6 +11,12 @@ const set = Ember.set;
 module('Acceptance | tether test', {
   beforeEach: function() {
     application = startApp();
+    viewRegistry = application.__container__.lookup('-view-registry:main');
+
+    // for < 1.12.0 support
+    if (!viewRegistry) {
+      viewRegistry = Ember.View.views;
+    }
   },
 
   afterEach: function() {
@@ -48,7 +54,7 @@ assert.classAbsent = function(thingSelector, className) {
 
 function getTetherComponent(selector) {
   const anotherEl = Ember.$(selector)[0];
-  return Ember.View.views[anotherEl.id];
+  return viewRegistry[anotherEl.id];
 }
 
 test('tethering a thing to a target', function(assert) {


### PR DESCRIPTION
In Ember 1.13+ Ember.View is a different deprecated class than the parent class of `Ember.Component`, so checking for `t instanceof Ember.View` when `t` was a component would not return true.

I discovered this while updating ember-modal-dialog to Ember 1.13.

This issue blocks updating that lib.