### PR TITLE
Updates tether.js and wormhole

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
+import EmberWormhole from 'ember-wormhole/components/ember-wormhole';
+import layout from '../templates/components/ember-tether';
 
 const { observer, get, run, computed } = Ember;
 
-export default Ember.Component.extend({
-  classNames: ['ember-tether'],
+const { reads } = computed;
+
+export default EmberWormhole.extend({
+  layout: layout,
   classPrefix: 'ember-tether',
   target: null,
   attachment: null,
@@ -14,15 +18,19 @@ export default Ember.Component.extend({
   constraints: null,
   optimizations: null,
 
+  to: reads('wormholeTargetService.defaultTargets.emberTether'),
+
   didInsertElement: function() {
+    this._super();
+
     this.addTether();
   },
 
   willDestroyElement: function() {
+    this._super();
+
     var tether = this._tether;
-    var element = this.element;
     run.schedule('render', () => {
-      this.removeElement(element);
       this.removeTether(tether);
     });
   },
@@ -37,6 +45,8 @@ export default Ember.Component.extend({
     'targetModifier',
     'constraints',
     'optimizations',
+    'renderInPlace',
+    'destinationName',
     function() {
       this.removeTether(this._tether);
       this.addTether();
@@ -44,7 +54,7 @@ export default Ember.Component.extend({
   ),
 
   addTether: function() {
-    if (get(this, '_tetherTarget')) {
+    if (!this.get('renderInPlace') && get(this, '_tetherTarget')) {
       this._tether = new Tether(this._tetherOptions());
     }
   },
@@ -52,12 +62,6 @@ export default Ember.Component.extend({
   removeTether: function(tether) {
     if (tether) {
       tether.destroy();
-    }
-  },
-
-  removeElement: function(element) {
-    if (element.parentNode) {
-      element.parentNode.removeChild(element);
     }
   },
 
@@ -71,8 +75,9 @@ export default Ember.Component.extend({
 
   _tetherOptions: function() {
     let options = {
-      element: this.element,
-      target: get(this, '_tetherTarget')
+      element: this._firstNode,
+      target: get(this, '_tetherTarget'),
+      moveRoot: false
     };
     [ 'classPrefix',
       'attachment',

--- a/addon/initializers/add-tether-container.js
+++ b/addon/initializers/add-tether-container.js
@@ -1,0 +1,11 @@
+export function initialize(container, application) {
+  const emberTether = application.emberTether || {};
+  const tetherContainerId = emberTether.defaultContainerId || 'tether-outlet';
+
+  container.lookup('service:wormhole-target').addDefaultTarget('emberTether', tetherContainerId);
+}
+
+export default {
+  name: 'add-tether-container',
+  initialize: initialize
+};

--- a/addon/templates/components/ember-tether.hbs
+++ b/addon/templates/components/ember-tether.hbs
@@ -1,0 +1,3 @@
+<div class="ember-tether {{class}}">
+  {{yield}}
+</div>

--- a/app/initializers/add-tether-container.js
+++ b/app/initializers/add-tether-container.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-tether/initializers/add-tether-container';

--- a/app/services/ember-tether.js
+++ b/app/services/ember-tether.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-tether/services/ember-tether';

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "jquery": "^1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
-    "tether": "~0.7.2"
+    "tether": "pzuraq/tether#add-option-to-disable-move-element"
   }
 }

--- a/index.js
+++ b/index.js
@@ -11,9 +11,6 @@ module.exports = {
   },
 
   importBowerDependencies: function(app) {
-    app.import(app.bowerDirectory + '/tether/js/utils.js');
-    app.import(app.bowerDirectory + '/tether/js/tether.js');
-    app.import(app.bowerDirectory + '/tether/js/abutment.js');
-    app.import(app.bowerDirectory + '/tether/js/constraint.js');
+    app.import(app.bowerDirectory + '/tether/dist/js/tether.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-github-pages": "0.0.6",
-    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.13",
@@ -40,7 +39,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-wormhole": "^0.3.1"
+    "ember-cli-htmlbars": "0.7.6",
+    "ember-wormhole": "https://github.com/pzuraq/ember-wormhole.git#split-wormhole-logic-into-service"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/acceptance/tether-test.js
+++ b/tests/acceptance/tether-test.js
@@ -20,6 +20,9 @@ module('Acceptance | tether test', {
   },
 
   afterEach: function() {
+    Ember.run(() => {
+      application.__container__.lookup('service:wormhole-target').get('targets').clear();
+    });
     Ember.run(application, 'destroy');
   }
 });
@@ -31,6 +34,15 @@ assert.topAligned = function(thingSelector, targetSelector) {
   const withinOnePixel = topDifference < 1;
   assert.ok(withinOnePixel, `${thingSelector} top within one pixel of ${targetSelector} top`);
 };
+
+assert.bottomAligned = function(thingSelector, targetSelector) {
+  const thing = Ember.$(thingSelector);
+  const target = Ember.$(targetSelector);
+  const topDifference = abs(thing.offset().top - (target.offset().top + target.outerHeight()));
+  const withinOnePixel = topDifference < 1;
+  assert.ok(withinOnePixel, `${thingSelector} top within one pixel of ${targetSelector} bottom`);
+};
+
 assert.leftOf = function(thingSelector, targetSelector) {
   const thing = Ember.$(thingSelector);
   const target = Ember.$(targetSelector);
@@ -52,10 +64,6 @@ assert.classAbsent = function(thingSelector, className) {
   assert.ok(thing.attr('class').indexOf(className) <= -1);
 };
 
-function getTetherComponent(selector) {
-  const anotherEl = Ember.$(selector)[0];
-  return viewRegistry[anotherEl.id];
-}
 
 test('tethering a thing to a target', function(assert) {
   visit('/');
@@ -86,15 +94,12 @@ test('changing tether attachment', function(assert) {
     assert.leftOf('.another-tethered-thing', '#tether-target-3');
   });
 
-  andThen(function() {
-    const anotherThing = getTetherComponent('.another-tethered-thing');
-    set(anotherThing, 'attachment', 'top left');
-    set(anotherThing, 'targetAttachment', 'top right');
-  });
+  click('.demo button:contains(Rotate Tether)');
+  click('.demo button:contains(Rotate Tether)');
 
   andThen(function() {
-    assert.topAligned('.another-tethered-thing', '#tether-target-3');
-    assert.rightOf('.another-tethered-thing', '#tether-target-3');
+    assert.bottomAligned('.another-tethered-thing', '#tether-target-3');
+    assert.leftOf('.another-tethered-thing', '#tether-target-3');
   });
 });
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -19,6 +19,7 @@ body {
   background-color: orange;
   border: dotted 3px blue;
   display: block;
+  position: absolute;
 }
 
 .example-view {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{ember-wormhole-targets}}
+
 <h2 id="title">Ember Tether</h2>
 <p>
   Ember Tether is throwing an 80s party, in honor of what was arguably

--- a/tests/index.html
+++ b/tests/index.html
@@ -15,30 +15,8 @@
     <link rel="stylesheet" href="assets/test-support.css">
 
     <style>
-      #ember-testing-container {
-        position: absolute;
-        background: rgba(255, 0, 255, 0.1);
-        bottom: 0;
-        right: 0;
-        width: initial;
-        height: initial;
-        overflow: auto;
-        z-index: 9999;
-        border: 10px solid lime;
-      }
-      #ember-testing {
-        zoom: 100%;
-      }
-      .note {
-        font-size: 1.5rem;
-        margin: 5px auto;
-        background-color: cyan;
-        border: dotted 10px black;
-        padding: 10px 100px;
-        width: 80%;
-      }
-      strong {
-        color: white;
+      .wormhole-root-target {
+        position: fixed;
       }
     </style>
 
@@ -46,12 +24,6 @@
     {{content-for 'test-head-footer'}}
   </head>
   <body>
-    <p class='note'>
-      <strong>NOTE:</strong> We have freed the #ember-testing-container div from its usual bounds
-      and set the #ember-testing-container zoom to 100% in order to observe and
-      properly test Ember Tether's positioning behavior.
-    </p>
-
     {{content-for 'body'}}
     {{content-for 'test-body'}}
     <script src="assets/vendor.js"></script>


### PR DESCRIPTION
This PR updates `tether.js` to a new version (merge still pending) which includes the ability to prevent tether.js from moving elements to the document body. We can instead extend `ember-wormhole` to warp the element near enough to the body that `ember-tether` can correctly position itself correctly, but still be in the context of the ember app. This opens up the possibility of animation with `liquid-fire`.

See [this PR](https://github.com/yapplabs/ember-wormhole/pull/20) on `ember-wormhole` and [this example app](https://github.com/pzuraq/wormhole-liquid-test)