### PR TITLE
Enable a way to inject Hubspot Tether modules into ember-tether.

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import TransitionModule from 'ember-tether/modules/transition-module';
 
 const { observer, get, run, computed } = Ember;
 
@@ -46,6 +47,7 @@ export default Ember.Component.extend({
 
   addTether() {
     if (get(this, '_tetherTarget')) {
+      Tether.modules.push(TransitionModule);
       this._tether = new Tether(this._tetherOptions());
     }
   },

--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import TransitionModule from 'ember-tether/modules/transition-module';
 
 const { observer, get, run, computed } = Ember;
 
@@ -14,10 +13,17 @@ export default Ember.Component.extend({
   targetModifier: null,
   constraints: null,
   optimizations: null,
+  modules: null,
 
   didInsertElement() {
     this.addTether();
     this._super(...arguments);
+    let modules = this.get('modules');
+    if (modules) {
+      modules.forEach((module) => {
+        Tether.modules.push(module);
+      });
+    }
   },
 
   willDestroyElement() {
@@ -47,7 +53,6 @@ export default Ember.Component.extend({
 
   addTether() {
     if (get(this, '_tetherTarget')) {
-      Tether.modules.push(TransitionModule);
       this._tether = new Tether(this._tetherOptions());
     }
   },

--- a/addon/modules/transition-module.js
+++ b/addon/modules/transition-module.js
@@ -1,0 +1,26 @@
+let transitionModule = {
+  className: 'transition',
+  thresholdX: 50,
+  thresholdY: 50,
+
+  position(props) {
+    let className = `${this.options.classPrefix}-${transitionModule.className}`;
+    let hasClass = Tether.Utils.hasClass(this.element, className);
+    let lastOffset = this._cacheOffset;
+
+    let shouldAddClass = lastOffset &&
+      Math.abs(props.left - lastOffset[0]) <= transitionModule.thresholdX &&
+      Math.abs(props.top - lastOffset[1]) <= transitionModule.thresholdY;
+
+    if (!hasClass && shouldAddClass) {
+      Tether.Utils.addClass(this.element, className);
+    } else if (hasClass && !shouldAddClass) {
+      Tether.Utils.removeClass(this.element, className);
+    }
+
+    // Cache the offset
+    this._cacheOffset = [props.left, props.top];
+  }
+};
+
+export default transitionModule;

--- a/addon/modules/transition-module.js
+++ b/addon/modules/transition-module.js
@@ -5,7 +5,6 @@ let transitionModule = {
 
   position(props) {
     let className = `${this.options.classPrefix}-${transitionModule.className}`;
-    console.log(className);
     let hasClass = Tether.Utils.hasClass(this.element, className);
     let lastOffset = this._cacheOffset;
 

--- a/addon/styles/app.css
+++ b/addon/styles/app.css
@@ -1,0 +1,11 @@
+.ember-tether-transition {  
+  /* 
+   * These rules are just here for information purposes.
+   * If you uncomment them the tests will fail.
+   */
+
+  /*
+   * transition: -webkit-transform 80ms ease-in-out;
+   * transition: transform 80ms ease-in-out;
+   */
+}

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-tether",
   "dependencies": {
     "bind-polyfill": "~1.0.0",
-    "ember": "1.10.1",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
@@ -13,8 +13,5 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "tether": "^1.0.3"
-  },
-  "resolutions": {
-    "ember": "1.10.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-tether",
   "dependencies": {
     "bind-polyfill": "~1.0.0",
-    "ember": "1.13.2",
+    "ember": "1.10.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
@@ -13,5 +13,8 @@
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "tether": "^1.0.3"
+  },
+  "resolutions": {
+    "ember": "1.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-suave": "1.2.3",
+    "ember-suave": "1.2.2",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-suave": "1.2.2",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.6"
   },
   "keywords": [

--- a/tests/acceptance/tether-test.js
+++ b/tests/acceptance/tether-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import QUnit from 'qunit';
 import { module, test } from 'qunit';
 import startApp from '../helpers/start-app';
+import TestTransitionModule from 'dummy/modules/test-transition-module';
 
 let application, viewRegistry;
 const { assert } = QUnit;
@@ -124,5 +125,12 @@ test('surviving target removal', function(assert) {
     assert.rightOf('.third-tethered-thing', '#tether-target-2 .within');
     assert.classPresent('.third-tethered-thing', 'ember-tether-enabled');
     assert.ok(Ember.$('.third-tethered-thing .highlight').text() === 'true');
+  });
+});
+
+test('passing in tether modules', function(assert) {
+  visit('/');
+  andThen(function() {
+    assert.ok(window.Tether.modules.slice(-1)[0].className === TestTransitionModule.className);
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import TestTransitionModule from '../modules/test-transition-module';
 
 const { computed, get, set, observer, run } = Ember;
 
@@ -24,6 +25,7 @@ export default Ember.Controller.extend({
   ],
   attachmentConfigurationIndex: 0,
 
+  testModules: [TestTransitionModule],
   exampleTargetAttachment: computed('attachmentConfigurationIndex', function() {
     const i = get(this, 'attachmentConfigurationIndex');
     const config = get(this, 'attachmentConfigurations')[i];

--- a/tests/dummy/app/modules/test-transition-module.js
+++ b/tests/dummy/app/modules/test-transition-module.js
@@ -5,8 +5,7 @@ let transitionModule = {
 
   position(props) {
     let className = `${this.options.classPrefix}-${transitionModule.className}`;
-    console.log(className);
-    let hasClass = Tether.Utils.hasClass(this.element, className);
+    let hasClass = window.Tether.Utils.hasClass(this.element, className);
     let lastOffset = this._cacheOffset;
 
     let shouldAddClass = lastOffset &&
@@ -14,9 +13,9 @@ let transitionModule = {
       Math.abs(props.top - lastOffset[1]) <= transitionModule.thresholdY;
 
     if (!hasClass && shouldAddClass) {
-      Tether.Utils.addClass(this.element, className);
+      window.Tether.Utils.addClass(this.element, className);
     } else if (hasClass && !shouldAddClass) {
-      Tether.Utils.removeClass(this.element, className);
+      window.Tether.Utils.removeClass(this.element, className);
     }
 
     // Cache the offset

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -57,6 +57,7 @@
       attachment='top left'
       class='tethered-thing'
       offset=exampleOffset
+      modules=testModules
   }}
     A tethered thing
   {{/ember-tether}}
@@ -90,5 +91,4 @@
   }}
     Component
   {{/ember-tether}}
-
 </div>


### PR DESCRIPTION
I needed to use tether modules, which need to be loaded into Tether. I have enabled the option of passing in a `modules` property to the `ember-tether` component. This allows anyone using ember-tether to pass in an existing hubspot tether module without needing to have an initializer or other ugly code.
cheers

NOTE: Needs merged first https://github.com/yapplabs/ember-tether/pull/20 so that we can get the tests to pass in this branch.