### PR TITLE
Updates ember-suave so we can run the tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-suave": "1.2.2",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.6"
   },
   "keywords": [


### PR DESCRIPTION
Without updating `ember-suave`, the tests fail with an error:
`Rule "disallowVar" is already registered`

I needed to fix this so that I could run the tests and make this PR: https://github.com/yapplabs/ember-tether/pull/19