### PR TITLE
Add position call afterRender to ensure position after render

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -16,6 +16,12 @@ export default Ember.Component.extend({
 
   didInsertElement() {
     this.addTether();
+    run.scheduleOnce('afterRender', () => {
+      const { _tether } = this;
+      if (_tether) {
+        _tether.position();
+      }
+    });
     this._super(...arguments);
   },
 


### PR DESCRIPTION
Fixes #6 

Unfortunately, I was not able to reproduce this in the dummy app. Since it occurs consistently in my app, I've tried these things in both my app and the dummy app:

* Removing all CSS
* Rendering conditionally and unconditionally via HTMLBars
* Nesting the tether or the target in components, other elements, etc
* Different variations of box model manipulations (min-width, padding, overflow, etc)