### PR TITLE
Call tether.position() on didRender.

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -28,6 +28,10 @@ export default Ember.Component.extend({
     this._super(...arguments);
   },
 
+  didRender() {
+    this._tether.position();
+  },
+
   tetherDidChange: observer(
     'classPrefix',
     'target',


### PR DESCRIPTION
Prior to this change, tethers could be positioned incorrectly on page load in later versions of Ember (see:
https://github.com/yapplabs/ember-tether/issues/6) and would fix themselves as soon as the page was resized or scrolled.

I created https://github.com/cball/incorrect-ember-tether-position-example as a reproducible case. The `master` branch has the incorrect position, and the `patched-ember-tether` branch is pointing to the code in this PR.

Fixes #6.