### PR TITLE
Call tether.position() on didRender.

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -15,17 +15,22 @@ export default Ember.Component.extend({
   optimizations: null,
 
   didInsertElement() {
-    this.addTether();
     this._super(...arguments);
+    this.addTether();
   },
 
   willDestroyElement() {
+    this._super(...arguments);
     const { _tether, element } = this;
     run.schedule('render', () => {
       this.removeElement(element);
       this.removeTether(_tether);
     });
+  },
+
+  didRender() {
     this._super(...arguments);
+    this.positionTether();
   },
 
   tetherDidChange: observer(
@@ -43,6 +48,12 @@ export default Ember.Component.extend({
       this.addTether();
     }
   ),
+
+  positionTether() {
+    if (this._tether) {
+      this._tether.position();
+    }
+  },
 
   addTether() {
     if (get(this, '_tetherTarget')) {

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1",
     "tether": "^1.0.3"


### PR DESCRIPTION
Prior to this change, tethers could be positioned incorrectly on page
load in later versions of Ember (see:
https://github.com/yapplabs/ember-tether/issues/6) and would fix themselves as soon as the page was resized or
scrolled.

Fixes #6.
Supersedes and closes #24 

- Call `this._super()` first and throughout
- Pin jquery for dummy app