### PR TITLE
Pull tether from npm instead of Bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,24 +66,11 @@ and remove it when the route is exited.
 
 ## Using ember-tether in Your Own Addon
 
-ember-tether depends on [Hubspot Tether](http://github.hubspot.com/tether/), which is imported as a bower dependency. When using ember-tether directly in an Ember app, everything will work out of the box with no configuration
-necessary.
+ember-tether depends on [Hubspot Tether](http://github.hubspot.com/tether/), which is imported as a globals-style JS dependency. When using ember-tether directly in an Ember app, everything will work out of the box with no configuration necessary.
 
 However, addons nested in other addons do not have access to `app.import` in their included hook and are therefore unable to import their own dependencies. This is not a problem unique to ember-tether.
 
-The bad news is that this makes it more difficult to use ember-tether in an addon you may be developing. The good news is that ember-tether provides an `importBowerDependencies` hook for just this purpose.
-
-So... when using ember-tether nested within your addon, use the following code in the addon's `included` hook:
-
-```javascript
-included: function(app){
-  this._super.included.apply(this, app);
-  var emberTetherAddon = this.addons.filter(function(addon) {
-    return addon.name == 'ember-tether';
-  })[0];
-  emberTetherAddon.importBowerDependencies(app);
-},
-```
+The solution to this is to declare ember-tether as a `peerDependency` to ensure that it gets installed alongside your addon as a dependency of the root application. You'll likely also want it as a `devDependency` so that it's available during development and testing.
 
 ## Development Setup
 

--- a/blueprints/ember-tether/index.js
+++ b/blueprints/ember-tether/index.js
@@ -1,7 +1,0 @@
-module.exports = {
-  normalizeEntityName: function() {},
-
-  afterInstall: function() {
-    return this.addBowerPackageToProject('tether', '^1.0.3');
-  }
-};

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "ember-resolver": "~0.1.15",
     "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1",
-    "tether": "^1.0.3"
+    "qunit": "~1.17.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,13 +4,12 @@
 module.exports = {
   name: 'ember-tether',
 
-  included: function(app) {
-    if (app.import) {
-      this.importBowerDependencies(app);
+  options: {
+    nodeAssets: {
+      tether: {
+        srcDir: 'dist',
+        import: ['js/tether.js']
+      }
     }
-  },
-
-  importBowerDependencies: function(app) {
-    app.import(app.bowerDirectory + '/tether/dist/js/tether.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "tether"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-cli-node-assets": "^0.1.1",
+    "tether": "^1.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
I'm on a quest to start removing Bower dependencies from our apps where possible in the ultimate hope that once [Ember itself gets addonized](https://github.com/ember-cli/ember-cli/issues/4546) we'll be able stop using Bower entirely.

This change switches ember-tether over to import Tether from npm, and eliminates the default blueprint that added the tether Bower package on install.

For consuming applications, this doesn't change much, but unfortunately it does represent a breaking change for addons that rely on ember-tether. To consume ember-tether from an addon moving forward, the recommendation would be to declare it as a peerDependency, which would be consistent with [guidance coming from the core team](https://github.com/ember-cli/ember-cli/issues/3718#issuecomment-166644137), and it's the solution Ember Data went with for its `ember-inflector` dependency [as of the 2.3 release](https://github.com/emberjs/data/blob/master/package.json#L84-L86).