### PR TITLE
add a polyfill for Ember.getOwner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-1.13.2
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "ember-tether",
   "dependencies": {
-    "ember": "~2.10.0",
+    "ember": "components/ember#lts-2-4",
     "ember-cli-shims": "0.1.3"
+  },
+  "resolutions": {
+    "ember": "lts-2-4"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,17 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.13.2',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#1.13.2'
+        },
+        resolutions: {
+          'ember': '1.13.2'
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -29,13 +29,14 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.0.4",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-getowner-polyfill": "1.2.2",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.1.1",
     "ember-suave": "4.0.1",
-    "ember-cli-test-loader": "^1.1.0",
     "loader.js": "^4.0.10"
   },
   "keywords": [


### PR DESCRIPTION
As per the discussion over on https://github.com/sir-dunxalot/ember-tooltips/pull/162, this PR adds a polyfill for `Ember.getOwner`, in an attempt to make this addon compatible with Ember 1.13 again. I believe I have the tests passing using ember-try