### PR TITLE
Fix error in component integration tests

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -14,7 +14,7 @@ export default Component.extend({
   constraints: null,
   optimizations: null,
   emberTetherConfig: computed(function() {
-    return getOwner(this).resolveRegistration('config:environment')['ember-tether'];
+    return (getOwner(this).resolveRegistration('config:environment') || {})['ember-tether'];
   }),
   bodyElement: computed(function() {
     let config = get(this, 'emberTetherConfig');


### PR DESCRIPTION
In a component integration test, `getOwner(this).resolveRegistration('config:environment')` returns `undefined`. It therefore fails with `Uncaught TypeError: Cannot read property 'ember-tether' of undefined`.

This PR provides a fallback.