### PR TITLE
Add global aria attribute bindings

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -22,6 +22,27 @@ export default Component.extend({
       return document.getElementById(config.bodyElementId);
     }
   }),
+  attributeBindings: [
+    'aria-atomic',
+    'aria-busy',
+    'aria-controls',
+    'aria-current',
+    'aria-describedby',
+    'aria-details',
+    'aria-disabled',
+    'aria-errormessage',
+    'aria-flowto',
+    'aria-haspopup',
+    'aria-hidden',
+    'aria-invalid',
+    'aria-keyshortcuts',
+    'aria-label',
+    'aria-labelledby',
+    'aria-live',
+    'aria-owns',
+    'aria-relevant',
+    'aria-roledescription'
+  ],
   didInsertElement() {
     this._super(...arguments);
     this.addTether();

--- a/tests/acceptance/tether-test.js
+++ b/tests/acceptance/tether-test.js
@@ -43,6 +43,11 @@ assert.classAbsent = function(thingSelector, className) {
   assert.ok(thing.attr('class').indexOf(className) <= -1);
 };
 
+assert.attribute = function(thingSelector, attributeName, attributeValue) {
+  let thing = $(thingSelector);
+  assert.equal(thing.attr(attributeName), attributeValue, `${attributeName} has value ${attributeValue}`);
+}
+
 function getTetherComponent(selector) {
   // jscs:disable
   let anotherEl = $(selector)[0];
@@ -114,5 +119,37 @@ test('surviving target removal', function(assert) {
     assert.rightOf('.third-tethered-thing', '#tether-target-2 .within');
     assert.classPresent('.third-tethered-thing', 'ember-tether-enabled');
     assert.ok($('.third-tethered-thing .highlight').text() === 'true');
+  });
+});
+
+test('binding accessibility elements', function(assert) {
+  visit('/');
+
+  let expectedAttributes = {
+    'aria-atomic': 'true',
+    'aria-busy': 'true',
+    'aria-controls': 'element-id',
+    'aria-current': 'current-element-id',
+    'aria-describedby': 'described-element-id',
+    'aria-details': 'details-element-id',
+    'aria-disabled': 'true',
+    'aria-errormessage': 'errormessage-element-id',
+    'aria-flowto': 'flowto-elemenet-id',
+    'aria-haspopup': 'grid',
+    'aria-hidden': 'true',
+    'aria-invalid': 'true',
+    'aria-keyshortcuts': 'A',
+    'aria-label': 'tether-label',
+    'aria-labelledby': 'labelledby-element-id',
+    'aria-live': 'polite',
+    'aria-owns': 'owns-element-id',
+    'aria-relevant': 'additions',
+    'aria-roledescription': 'tether-role-description'
+  };
+  andThen(function() {
+    assert.attribute('.accessible-thing', 'role', 'region');
+    Object.keys(expectedAttributes).forEach((attributeName) => {
+      assert.attribute('.accessible-thing', attributeName, expectedAttributes[attributeName]);
+    })
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -91,4 +91,35 @@
     Component
   {{/ember-tether}}
 
+
+  {{#ember-tether
+      target='#tether-target-5'
+      targetAttachment='top right'
+      attachment='top left'
+      class='accessible-thing'
+      offset=exampleOffset
+      ariaRole='region'
+      aria-atomic='true'
+      aria-busy='true'
+      aria-controls='element-id'
+      aria-current='current-element-id'
+      aria-describedby='described-element-id'
+      aria-details='details-element-id'
+      aria-disabled='true'
+      aria-errormessage='errormessage-element-id'
+      aria-flowto='flowto-elemenet-id'
+      aria-haspopup='grid'
+      aria-hidden='true'
+      aria-invalid='true'
+      aria-keyshortcuts='A'
+      aria-label='tether-label'
+      aria-labelledby='labelledby-element-id'
+      aria-live='polite'
+      aria-owns='owns-element-id'
+      aria-relevant='additions'
+      aria-roledescription='tether-role-description'
+  }}
+    A tethered thing with aria attributes
+  {{/ember-tether}}
+
 </div>


### PR DESCRIPTION
Fixes #50 
Manually adding the global aria attributes that can be set on the tether element. 
Doing this manually limits the scope and avoids the performance impact discussions that have prevented automatic aria attribute binding within ember.js (hopefully) :)