### PR TITLE
Fix error on willDestroyElement when running in fastboot

### DIFF
--- a/addon/components/ember-tether.js
+++ b/addon/components/ember-tether.js
@@ -29,6 +29,8 @@ export default Component.extend({
 
   willDestroyElement() {
     this._super(...arguments);
+    if (!this._tether) return;
+
     let { _tether, element } = this;
     run.schedule('render', () => {
       this.removeElement(element);


### PR DESCRIPTION
I was getting an error when running in FastBoot about accessing `this.element`.  This solves that problem. 