### PR TITLE
Drop support for Node.js 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "qunit-dom": "^0.8.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Both of these versions are no longer supported by the Node.js teams and dropping support for them here should hopefully fix our CI builds 🙏 