### PR TITLE
Add support for Ember v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack": "^5.78.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0"
+    "ember-source": ">=4.0.0"
   },
   "engines": {
     "node": "14.* || 16.* || >= 18"


### PR DESCRIPTION
Without this change, you have an issue installing Ember.js v5:

```
unmet peer ember-source@^4.0.0: found 5.3.0
```